### PR TITLE
ci: rename tasks with correct verb tenses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-        name: Running black in all files.
+        name: Run black in files
 
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
         args: ["--profile", "black", "--extend-skip", "examples"]
-        name: Running isort in all files.
+        name: Run isort in files
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0


### PR DESCRIPTION
Signed-off-by: MaskDuck <it-is@too-obvious-that.maskduck.is-a.dev>